### PR TITLE
-->> RDP Wrapper & Autoupdate (07-06-2020)

### DIFF
--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -7,7 +7,7 @@ REM -------------------------------------------------------------------
 REM
 REM                        autoupdate.bat
 REM
-REM Automatic RDP Wrapper installer and updater // asmtron (15-08-2019)
+REM Automatic RDP Wrapper installer and updater // asmtron (16-08-2019)
 REM -------------------------------------------------------------------
 REM Options:
 REM   -log        = redirect display output to the file autoupdate.log
@@ -214,31 +214,23 @@ REM -------------------
 if %rdpwrap_installed%=="0" (
     call :install
 )
-REM NOTE normal copy of the file "rdpwrap_new.ini" to "rdpwrap.ini" will not work (file locked)
-REM      we need to stream the data line by line from "rdpwrap_new.ini" to "rdpwrap.ini"
+REM NOTE - normal copy of the file "rdpwrap_new.ini" to "rdpwrap.ini" will not work (file locked)
+REM        we need to stream the data from "rdpwrap_new.ini" to "rdpwrap.ini"
 if exist %rdpwrap_new_ini% (
     echo [*] Start streaming %rdpwrap_new_ini% to %rdpwrap_ini%...
-    set firstline="0"
-    for /f "usebackq delims=" %%a in (
-        `findstr /n "^" %rdpwrap_new_ini%`
-    ) do (
-        set "line=!%%a!"
-        set "line=!line:*:=!"
-        if !firstline!=="0" (
-            set firstline="1"
+    (
+        for /f "usebackq delims=" %%a in (
+            `findstr /n "^" %rdpwrap_new_ini%`
+        ) do (
+            set "line=!%%a!"
+            set "line=!line:*:=!"
             if "!line!"=="*:=" (
-                echo.>%rdpwrap_ini%
+                echo.
             ) else (
-                echo !line!>%rdpwrap_ini%
-            )
-        ) else (
-            if "!line!"=="*:=" (
-                echo.>>%rdpwrap_ini%
-            ) else (
-                echo !line!>>%rdpwrap_ini%
+                echo !line!
             )
         )
-    )
+    )>%rdpwrap_ini%
     echo [+] Update of %rdpwrap_ini% finished successfully.
 )
 echo.

--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -1,0 +1,264 @@
+<!-- : Begin batch script
+@echo off
+setLocal EnableExtensions
+setlocal EnableDelayedExpansion
+
+REM -------------------------------------------------------------------
+REM
+REM                        autoupdate.bat
+REM
+REM Automatic RDP Wrapper installer and updater // asmtron (11-08-2019)
+REM -------------------------------------------------------------------
+REM Options:
+REM   -log        = redirect display output to the file autoupdate.log
+REM   -taskadd    = add autorun of autoupdate.bat on startup in schedule task
+REM   -taskremove = remove autorun of autoupdate.bat on startup in schedule task
+REM
+REM Info: 
+REM   The autoupdater first use and check the official rdpwrap.ini.
+REM   If a new termsrv.dll is not supported in the offical rdpwrap.ini,
+REM   autoupdater first tries the asmtron rdpwrap.ini (disassembled and
+REM   tested by asmtron). The autoupdater will also use rdpwrap.ini files
+REM   of other contributors like the one of "saurav-biswas".
+REM   Extra rdpwrap.ini sources can also be defined...
+REM
+REM { Special thak to binarymaster, saurav-biswas and all other contributors }
+
+REM -----------------------------------------
+REM Location of new/updated rdpwrap.ini files
+REM -----------------------------------------
+set rdpwrap_ini_update_github_1="https://raw.githubusercontent.com/asmtron/rdpwrap/patch-1/res/rdpwrap.ini"
+set rdpwrap_ini_update_github_2="https://raw.githubusercontent.com/saurav-biswas/rdpwrap-1/patch-1/res/rdpwrap.ini"
+REM set rdpwrap_ini_update_github_3="https://raw.githubusercontent.com/....Extra.3...."
+REM set rdpwrap_ini_update_github_4="https://raw.githubusercontent.com/....Extra.4...."
+
+set autoupdate_bat="%~dp0autoupdate.bat"
+set autoupdate_log="%~dp0autoupdate.log"
+set RDPWInst_exe="%~dp0RDPWInst.exe"
+set rdpwrap_ini="%~dp0rdpwrap.ini"
+set rdpwrap_ini_check=%rdpwrap_ini%
+set rdpwrap_new_ini="%~dp0rdpwrap_new.ini"
+set github_location=1
+
+
+echo ___________________________________________
+echo Automatic RDP Wrapper installer and updater
+echo.
+echo ^<check if the RDP Wrapper is up-to-date and working^>
+echo.
+REM check if admin
+fsutil dirty query %systemdrive% >nul
+if not %errorlevel% == 0 goto :not_admin
+REM check for arguments
+if /i "%~1"=="-log" (  
+  echo %autoupdate_bat% output from %date% at %time% > %autoupdate_log%
+  call %autoupdate_bat% >> %autoupdate_log%
+  goto :finish
+)
+if /i "%~1"=="-taskadd" (
+  echo [+] add autorun of %autoupdate_bat% on startup in the schedule task  
+  schtasks /create /f /sc ONSTART /tn "RDP Wrapper Autoupdate" /tr "cmd.exe /C \"%~dp0autoupdate.bat\" -log" /ru SYSTEM /delay 0000:10
+  goto :finish
+)
+if /i "%~1"=="-taskremove" (
+  echo [-] remove autorun of %autoupdate_bat% on startup in the schedule task  
+  schtasks /delete /f /tn "RDP Wrapper Autoupdate"
+  goto :finish
+)
+if /i not "%~1"=="" (
+  echo [x] Unknown argument specified: "%~1"
+  echo [~] Supported argments/options are:
+  echo     -log         =  redirect display output to the file autoupdate.log
+  echo     -taskadd     =  add autorun of autoupdate.bat on startup in the schedule task
+  echo     -taskremove  =  remove autorun of autoupdate.bat on startup in the schedule task
+  goto :finish
+)
+REM check if file "RDPWInst.exe" exist
+if not exist %RDPWInst_exe% goto :error_install
+goto :start_check
+
+:not_admin
+echo [-] This script must be run as administrator to work properly!
+echo     ^<Please use 'right click' on this batch file and select "Run As Administrator"^>
+echo.
+goto :finish
+:error_install
+echo [-] RDP Wrapper installer executable (RDPWInst.exe) not found!
+echo Please extract all files from the downloaded RDP-Wrapper package or check your Antivirus.
+echo.
+goto :finish
+
+:start_check
+REM ----------------------------------
+REM 1) check if TermService is running
+REM ----------------------------------
+sc queryex "TermService"|find "STATE"|find /v "RUNNING" >nul&&(
+    echo [-] TermService not running!
+    call :install
+)||(
+    echo [+] TermService running.
+)
+REM -----------------------------------------
+REM 2) check if rdpwrap.dll exist in registry
+REM -----------------------------------------
+reg query HKLM\SYSTEM\CurrentControlSet\Services\TermService\Parameters /f "rdpwrap.dll" >nul&&(
+    echo [+] Found windows registry entry for "rdpwrap.dll".
+)||(
+    echo [-] NOT found windows registry entry for "rdpwrap.dll"!
+    call :install
+)
+REM ------------------------------
+REM 3) check if rdpwrap.ini exists
+REM ------------------------------
+if exist %rdpwrap_ini% (
+    echo [+] Found file: %rdpwrap_ini%
+) else (
+    echo [-] File NOT found: %rdpwrap_ini%!
+    call :install
+)
+REM ---------------------------------------------------------------
+REM 4) check if installed termsrv.dll version exists in rdpwrap.ini
+REM ---------------------------------------------------------------
+:check_update
+for /f "tokens=* usebackq" %%a in (
+    `cscript //nologo "%~f0?.wsf" //job:fileVersion %windir%\System32\termsrv.dll`
+) do (
+    set "termsrv_dll_ver=%%a"
+)
+echo [+] Installed "termsrv.dll" version: %termsrv_dll_ver%
+if exist %rdpwrap_ini_check% (
+    echo [~] Start searching [%termsrv_dll_ver%] version entry in file %rdpwrap_ini_check% ...
+    findstr /c:"[%termsrv_dll_ver%]" %rdpwrap_ini_check% >nul&&(
+        echo [+] Found "termsrv.dll" version entry [%termsrv_dll_ver%] in file %rdpwrap_ini_check%
+        echo [~] RDP-Wrapper seems to be up-to-date and working...
+    )||(
+        echo [-] NOT found "termsrv.dll" version entry [%termsrv_dll_ver%] in file %rdpwrap_ini_check%!        
+        if not "!rdpwrap_ini_update_github_%github_location%!" == "" (            
+            set rdpwrap_ini_url=!rdpwrap_ini_update_github_%github_location%!
+        		call :update
+        		goto :check_update
+        )
+        goto :finish
+    )
+) else (
+    echo [-] File NOT found: %rdpwrap_ini_check%
+    echo [~] Give up - Please check if Antivirus/Firewall blocks the file %rdpwrap_ini_check%!
+    goto :finish
+)
+goto :finish
+
+REM -----------------------------------------------------
+REM Install RDP Wrapper (exactly uninstall and reinstall)
+REM -----------------------------------------------------
+:install
+echo.
+echo [~] Install RDP Wrapper ...
+echo.
+%RDPWInst_exe% -u
+%RDPWInst_exe% -i -o
+goto :eof
+
+REM -------------------
+REM Restart RDP-Wrapper
+REM -------------------
+:restart
+echo.
+echo [~] ReStart RDP Wrapper ...
+echo.
+%RDPWInst_exe% -r
+goto :eof
+
+REM --------------------------------------------------------------------
+REM Download up-to-date (alternative) version of rdpwrap.ini from GitHub
+REM --------------------------------------------------------------------
+:update
+set /a github_location=github_location+1
+echo.
+echo [~] Download latest version of rdpwrap.ini from GitHub
+echo     -^> %rdpwrap_ini_url%
+for /f "tokens=* usebackq" %%a in (
+    `cscript //nologo "%~f0?.wsf" //job:fileDownload %rdpwrap_ini_url% %rdpwrap_new_ini%`
+) do (
+    set "download_status=%%a"
+)
+if "%download_status%"=="-1" (
+    echo [+] Successfully download from GitHhub latest version to %rdpwrap_new_ini%
+    set rdpwrap_ini_check=%rdpwrap_new_ini%
+    echo [~] Start copy %rdpwrap_new_ini% to %rdpwrap_ini% ...
+    copy /y %rdpwrap_new_ini% %rdpwrap_ini%
+    call :restart
+) else (
+    echo [-] FAILED to download from GitHub latest version to %rdpwrap_new_ini%
+    echo [~] Please check you internet connection/firewall and try again!
+)
+goto :eof
+
+
+:finish
+echo.
+exit /b
+
+
+--- Begin wsf script --- fileVersion/fileDownload --->
+<package>
+  <job id="fileVersion"><script language="VBScript">
+    set args = WScript.Arguments
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    WScript.Echo fso.GetFileVersion(args(0))
+    Wscript.Quit
+  </script></job>
+  <job id="fileDownload"><script language="VBScript">
+    set args = WScript.Arguments
+    WScript.Echo SaveWebBinary(args(0), args(1))
+    Wscript.Quit
+    Function SaveWebBinary(strUrl, strFile) 'As Boolean
+        Const adTypeBinary = 1
+        Const adSaveCreateOverWrite = 2
+        Const ForWriting = 2
+        Dim web, varByteArray, strData, strBuffer, lngCounter, ado
+        On Error Resume Next
+        'Download the file with any available object
+        Err.Clear
+        Set web = Nothing
+        Set web = CreateObject("WinHttp.WinHttpRequest.5.1")
+        If web Is Nothing Then Set web = CreateObject("WinHttp.WinHttpRequest")
+        If web Is Nothing Then Set web = CreateObject("MSXML2.ServerXMLHTTP")
+        If web Is Nothing Then Set web = CreateObject("Microsoft.XMLHTTP")
+        web.Open "GET", strURL, False
+        web.Send
+        If Err.Number <> 0 Then
+            SaveWebBinary = False
+            Set web = Nothing
+            Exit Function
+        End If
+        If web.Status <> "200" Then
+            SaveWebBinary = False
+            Set web = Nothing
+            Exit Function
+        End If
+        varByteArray = web.ResponseBody
+        Set web = Nothing
+        'Now save the file with any available method
+        On Error Resume Next
+        Set ado = Nothing
+        Set ado = CreateObject("ADODB.Stream")
+        If ado Is Nothing Then
+            Set fs = CreateObject("Scripting.FileSystemObject")
+            Set ts = fs.OpenTextFile(strFile, ForWriting, True)
+            strData = ""
+            strBuffer = ""
+            For lngCounter = 0 to UBound(varByteArray)
+                ts.Write Chr(255 And Ascb(Midb(varByteArray,lngCounter + 1, 1)))
+            Next
+            ts.Close
+        Else
+            ado.Type = adTypeBinary
+            ado.Open
+            ado.Write varByteArray
+            ado.SaveToFile strFile, adSaveCreateOverWrite
+            ado.Close
+        End If
+        SaveWebBinary = True
+    End Function
+  </script></job>
+</package>  

--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -7,7 +7,7 @@ REM -------------------------------------------------------------------
 REM
 REM                        autoupdate.bat
 REM
-REM Automatic RDP Wrapper installer and updater // asmtron (20-08-2019)
+REM Automatic RDP Wrapper installer and updater // asmtron (07-09-2019)
 REM -------------------------------------------------------------------
 REM Options:
 REM   -log        = redirect display output to the file autoupdate.log
@@ -110,9 +110,7 @@ for /f "tokens=1-2* usebackq" %%a in (
 )
 if %rdp_tcp_session%=="" (
     echo [-] Listener session rdp-tcp NOT found^^!
-    if %rdpwrap_installed%=="0" (
-        call :install
-    )
+    call :install
 ) else (
     echo [+] Found listener session: %rdp_tcp_session% ^(ID: %rdp_tcp_session_id%^).
 )
@@ -224,12 +222,10 @@ if exist %rdpwrap_new_ini% (
         for /f "usebackq delims=" %%a in (
             `findstr /n "^" %rdpwrap_new_ini%`
         ) do (
-            set "line=!%%a!"
-            set "line=!line:*:=!"
-            if "!line!"=="*:=" (
+            if "!%%a!"=="" (
                 echo.
             ) else (
-                echo !line!
+                echo !%%a!
             )
         )
     )>%rdpwrap_ini%

--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -7,7 +7,7 @@ REM -------------------------------------------------------------------
 REM
 REM                        autoupdate.bat
 REM
-REM Automatic RDP Wrapper installer and updater // asmtron (14-08-2019)
+REM Automatic RDP Wrapper installer and updater // asmtron (15-08-2019)
 REM -------------------------------------------------------------------
 REM Options:
 REM   -log        = redirect display output to the file autoupdate.log
@@ -204,6 +204,7 @@ echo.
 set rdpwrap_installed="1"
 %RDPWInst_exe% -u
 %RDPWInst_exe% -i -o
+call :setNLA
 goto :eof
 
 REM -------------------
@@ -244,6 +245,7 @@ echo.
 echo [*] Restart RDP Wrapper...
 echo.
 %RDPWInst_exe% -r
+call :setNLA
 goto :eof
 
 REM --------------------------------------------------------------------
@@ -269,6 +271,14 @@ if "%download_status%"=="-1" (
 )
 goto :eof
 
+REM --------------------------------
+REM Set Network Level Authentication
+REM --------------------------------
+:setNLA
+echo [*] Set Network Level Authentication in the windows registry...
+reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v SecurityLayer /t reg_dword /d 0x2 /f
+reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v MinEncryptionLevel /t reg_dword /d 0x2 /f
+goto :eof
 
 :finish
 echo.

--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -27,7 +27,7 @@ REM { Special thak to binarymaster, saurav-biswas and all other contributors }
 REM -----------------------------------------
 REM Location of new/updated rdpwrap.ini files
 REM -----------------------------------------
-set rdpwrap_ini_update_github_1="https://raw.githubusercontent.com/asmtron/rdpwrap/patch-1/res/rdpwrap.ini"
+set rdpwrap_ini_update_github_1="https://raw.githubusercontent.com/asmtron/rdpwrap/master/res/rdpwrap.ini"
 set rdpwrap_ini_update_github_2="https://raw.githubusercontent.com/saurav-biswas/rdpwrap-1/patch-1/res/rdpwrap.ini"
 REM set rdpwrap_ini_update_github_3="https://raw.githubusercontent.com/....Extra.3...."
 REM set rdpwrap_ini_update_github_4="https://raw.githubusercontent.com/....Extra.4...."

--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -7,7 +7,7 @@ REM -------------------------------------------------------------------
 REM
 REM                        autoupdate.bat
 REM
-REM Automatic RDP Wrapper installer and updater // asmtron (16-08-2019)
+REM Automatic RDP Wrapper installer and updater // asmtron (20-08-2019)
 REM -------------------------------------------------------------------
 REM Options:
 REM   -log        = redirect display output to the file autoupdate.log
@@ -110,7 +110,9 @@ for /f "tokens=1-2* usebackq" %%a in (
 )
 if %rdp_tcp_session%=="" (
     echo [-] Listener session rdp-tcp NOT found^^!
-    call :install
+    if %rdpwrap_installed%=="0" (
+        call :install
+    )
 ) else (
     echo [+] Found listener session: %rdp_tcp_session% ^(ID: %rdp_tcp_session_id%^).
 )

--- a/bin/helper/autoupdate__disable_autorun_on_startup.bat
+++ b/bin/helper/autoupdate__disable_autorun_on_startup.bat
@@ -1,0 +1,9 @@
+@echo off
+if exist "%~dp0autoupdate.bat" (
+  call "%~dp0autoupdate.bat" -taskadd
+) else (
+  if exist "%~dp0..\autoupdate.bat" (
+    call "%~dp0..\autoupdate.bat"  -taskadd
+  )
+)
+pause

--- a/bin/helper/autoupdate__disable_autorun_on_startup.bat
+++ b/bin/helper/autoupdate__disable_autorun_on_startup.bat
@@ -1,9 +1,9 @@
 @echo off
 if exist "%~dp0autoupdate.bat" (
-  call "%~dp0autoupdate.bat" -taskadd
+  call "%~dp0autoupdate.bat" -taskremove
 ) else (
   if exist "%~dp0..\autoupdate.bat" (
-    call "%~dp0..\autoupdate.bat"  -taskadd
+    call "%~dp0..\autoupdate.bat"  -taskremove
   )
 )
 pause

--- a/bin/helper/autoupdate__enable_autorun_on_startup.bat
+++ b/bin/helper/autoupdate__enable_autorun_on_startup.bat
@@ -1,0 +1,9 @@
+@echo off
+if exist "%~dp0autoupdate.bat" (
+  call "%~dp0autoupdate.bat" -taskadd
+) else (
+  if exist "%~dp0..\autoupdate.bat" (
+    call "%~dp0..\autoupdate.bat"  -taskadd
+  )
+)
+pause

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -2,7 +2,7 @@
 
                         autoupdate.bat
 
- Automatic RDP Wrapper installer and updater // asmtron (20-08-2019)
+ Automatic RDP Wrapper installer and updater // asmtron (07-09-2019)
  -------------------------------------------------------------------
  Options:
    -log        = redirect display output to the file autoupdate.log
@@ -31,7 +31,7 @@
     USE ONLY the "%ProgramFiles%\RDP Wrapper" directory (normally C:\Program Files\RDP Wrapper)
 
 
- 2. Copy the files/folder from the archive "autoupdate-v20.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+ 2. Copy the files/folder from the archive "autoupdate-v07.09.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
 
 
  3. To enable autorun of autoupdate.bat on system startup, run the folling helper batch file as administrator:
@@ -42,6 +42,6 @@
  4. Set in your Antivirus/WindowsDefnder an exclusion on the folder "%ProgramFiles%\RDP Wrapper" to prevent the deletion of RDP Wrapper files
 
 
- 5. Now you can use the autoupdate batch file to install and update the RDP Wrapper. Please run the folling autoupdate batch file as administrator:
+ 5. Now you can use the autoupdate batch file to install and update the RDP Wrapper. Please run autoupdate.bat as administrator:
 
    "%ProgramFiles%\RDP Wrapper\autoupdate.bat"

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -1,0 +1,47 @@
+ -------------------------------------------------------------------
+
+                        autoupdate.bat
+
+ Automatic RDP Wrapper installer and updater // asmtron (11-08-2019)
+ -------------------------------------------------------------------
+ Options:
+   -log        = redirect display output to the file autoupdate.log
+   -taskadd    = add autorun of autoupdate.bat on startup in schedule task
+   -taskremove = remove autorun of autoupdate.bat on startup in schedule task
+
+ Info: 
+   The autoupdater first use and check the official rdpwrap.ini.
+   If a new termsrv.dll is not supported in the offical rdpwrap.ini,
+   autoupdater first tries the asmtron rdpwrap.ini (disassembled and
+   tested by asmtron). The autoupdater will also use rdpwrap.ini files
+   of other contributors like the one of "saurav-biswas".
+   Extra rdpwrap.ini sources can also be defined...
+
+ { Special thak to binarymaster, saurav-biswas and all other contributors }
+
+
+
+
+ INSTALL of RDP Wrapper and Autoupdater
+ ======================================
+
+ 1. Copy the files from the archive "RDPWrap-v1.6.2.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+
+    DO NOT use other location to install/extract the RDP Wrapper files.
+    USE ONLY the "%ProgramFiles%\RDP Wrapper" directory (normally C:\Program Files\RDP Wrapper)
+
+
+ 2. Copy the files/folder from the archive "autoupdate-v11.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+
+
+ 3. To enable autorun of autoupdate.bat on system startup, run the folling helper batch file as administrator:
+
+    "%ProgramFiles%\RDP Wrapper\helper\autoupdate__enable_autorun_on_startup.bat"
+
+
+ 4. Set in your Antivirus/WindowsDefnder an exclusion on the folder "%ProgramFiles%\RDP Wrapper" to prevent the deletion of RDP Wrapper files
+
+
+ 5. Now you can use the autoupdate batch file to install and update the RDP Wrapper. Please run autoupdate.bat as administrator:
+
+   "%ProgramFiles%\RDP Wrapper\autoupdate.bat"

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -2,7 +2,7 @@
 
                         autoupdate.bat
 
- Automatic RDP Wrapper installer and updater // asmtron (16-08-2019)
+ Automatic RDP Wrapper installer and updater // asmtron (20-08-2019)
  -------------------------------------------------------------------
  Options:
    -log        = redirect display output to the file autoupdate.log
@@ -31,7 +31,7 @@
     USE ONLY the "%ProgramFiles%\RDP Wrapper" directory (normally C:\Program Files\RDP Wrapper)
 
 
- 2. Copy the files/folder from the archive "autoupdate-v16.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+ 2. Copy the files/folder from the archive "autoupdate-v20.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
 
 
  3. To enable autorun of autoupdate.bat on system startup, run the folling helper batch file as administrator:

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -31,7 +31,7 @@
     USE ONLY the "%ProgramFiles%\RDP Wrapper" directory (normally C:\Program Files\RDP Wrapper)
 
 
- 2. Copy the files/folder from the archive "autoupdate-v11.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+ 2. Copy the files/folder from the archive "autoupdate-v15.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
 
 
  3. To enable autorun of autoupdate.bat on system startup, run the folling helper batch file as administrator:

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -2,7 +2,7 @@
 
                         autoupdate.bat
 
- Automatic RDP Wrapper installer and updater // asmtron (11-08-2019)
+ Automatic RDP Wrapper installer and updater // asmtron (15-08-2019)
  -------------------------------------------------------------------
  Options:
    -log        = redirect display output to the file autoupdate.log

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -2,7 +2,7 @@
 
                         autoupdate.bat
 
- Automatic RDP Wrapper installer and updater // asmtron (15-08-2019)
+ Automatic RDP Wrapper installer and updater // asmtron (16-08-2019)
  -------------------------------------------------------------------
  Options:
    -log        = redirect display output to the file autoupdate.log
@@ -31,7 +31,7 @@
     USE ONLY the "%ProgramFiles%\RDP Wrapper" directory (normally C:\Program Files\RDP Wrapper)
 
 
- 2. Copy the files/folder from the archive "autoupdate-v15.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
+ 2. Copy the files/folder from the archive "autoupdate-v16.08.2019.zip" (or newer) to the "%ProgramFiles%\RDP Wrapper" directory
 
 
  3. To enable autorun of autoupdate.bat on system startup, run the folling helper batch file as administrator:

--- a/bin/helper/autoupdate__info.txt
+++ b/bin/helper/autoupdate__info.txt
@@ -42,6 +42,6 @@
  4. Set in your Antivirus/WindowsDefnder an exclusion on the folder "%ProgramFiles%\RDP Wrapper" to prevent the deletion of RDP Wrapper files
 
 
- 5. Now you can use the autoupdate batch file to install and update the RDP Wrapper. Please run autoupdate.bat as administrator:
+ 5. Now you can use the autoupdate batch file to install and update the RDP Wrapper. Please run the folling autoupdate batch file as administrator:
 
    "%ProgramFiles%\RDP Wrapper\autoupdate.bat"

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2020-02-05
+Updated=2020-02-14
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -1776,6 +1776,32 @@ SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.14393.3471]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6528
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D931
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36C65
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31189
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=458A2
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3503]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A6528
 LocalOnlyCode.x86=jmpshort
@@ -4656,6 +4682,25 @@ ulMaxDebugSessions.x64=E847C
 bFUSEnabled.x64       =E8480
 
 [10.0.14393.3471-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
+[10.0.14393.3503-SLInit]
 bInitialized.x86      =C2F94
 bServerSku.x86        =C2F98
 lMaxUserSessions.x86  =C2F9C

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2019-09-02
+Updated=2020-02-05
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -1723,7 +1723,6 @@ SLInitHook.x86=1
 SLInitOffset.x86=45824
 SLInitFunc.x86=New_CSLQuery_Initialize
 
-
 [10.0.14393.2906]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A6578
@@ -1745,6 +1744,58 @@ DefPolicyOffset.x64=F185
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x86=1
 SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3383]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6578
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D8A1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3471]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6528
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D931
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36C65
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31189
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=458A2
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22C80
@@ -4541,6 +4592,44 @@ ulMaxDebugSessions.x86=C1FAC
 bFUSEnabled.x86       =C1FB0
 
 [10.0.14393.2906-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
+[10.0.14393.3383-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
+[10.0.14393.3471-SLInit]
 bInitialized.x86      =C2F94
 bServerSku.x86        =C2F98
 lMaxUserSessions.x86  =C2F9C

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3632,6 +3632,33 @@ SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17763.771]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFEB4
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D7F5
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BFF9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=5B30A
+SLInitFunc.x86=New_CSLQuery_Initialize
+
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77AD1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1339C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=18025
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=1ACDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.18362.1]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=B7A16
@@ -5907,6 +5934,25 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.771-SLInit]
+bInitialized.x86      =CD79C
+bServerSku.x86        =CD7A0
+lMaxUserSessions.x86  =CD7A4
+bAppServerAllowed.x86 =CD7AC
+bRemoteConnAllowed.x86=CD7B0
+bMultimonAllowed.x86  =CD7B4
+ulMaxDebugSessions.x86=CD7B8
+bFUSEnabled.x86       =CD7BC
+
+bServerSku.x64        =ECAB8
+lMaxUserSessions.x64  =ECABC
+bAppServerAllowed.x64 =ECAC4
+bInitialized.x64      =ECAB4
+bRemoteConnAllowed.x64=ECAC8
+bMultimonAllowed.x64  =ECACC
+ulMaxDebugSessions.x64=ECAD0
+bFUSEnabled.x64       =ECAD4
 
 [10.0.18362.1-SLInit]
 bInitialized.x86      =D477C

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3788,6 +3788,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.18362.657]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FB5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [SLInit]
 bServerSku=1
 bRemoteConnAllowed=1
@@ -6099,3 +6125,22 @@ bRemoteConnAllowed.x64=F6AA0
 bMultimonAllowed.x64  =F6AA4
 ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
+
+[10.0.18362.657-SLInit]
+bInitialized.x86 =D577C
+bServerSku.x86 =D5780
+lMaxUserSessions.x86 =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86 =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86 =D579C
+
+bInitialized.x64 =F6A8C
+bServerSku.x64 =F6A90
+lMaxUserSessions.x64 =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64 =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64 =F6AAC

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2019-08-02
+Updated=2019-09-02
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -93,6 +93,104 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=65FF7
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
+[6.0.6001.22286]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DDE
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C01
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22323]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C1D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22357]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185E4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70DFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=17FD8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65C1D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6001.22801]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=185F8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71ADA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=18010
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=666AD
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22515]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71AFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=6675D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22641]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71AFA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=6675D
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.22790]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71B02
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=66765
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
 [6.0.6002.23521]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=17FB4
@@ -107,6 +205,20 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=669CB
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
+[6.0.6003.20482]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FC4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=71F8A
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179DC
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=66B65
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
 [6.1.7600.16385]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=19E25
@@ -119,6 +231,20 @@ DefPolicyOffset.x86=196F3
 DefPolicyCode.x86=CDefPolicy_Query_eax_esi
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17AD2
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7600.20621]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=19E1D
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17DC2
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=196EB
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17ADE
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
 [6.1.7600.20890]
@@ -147,6 +273,20 @@ DefPolicyOffset.x86=196FB
 DefPolicyCode.x86=CDefPolicy_Query_eax_esi
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17B5E
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7600.21420]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=19EF5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17D56
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19761
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17B3E
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
 [6.1.7601.17514]
@@ -233,6 +373,48 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17D5E
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
+[6.1.7601.22213]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5AD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F26
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DB1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D06
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.22435]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5BD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F36
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DB1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D16
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.22476]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A5CD
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F56
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19DC1
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17D52
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
 [6.1.7601.22750]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=1A655
@@ -287,6 +469,34 @@ DefPolicyOffset.x86=19E41
 DefPolicyCode.x86=CDefPolicy_Query_eax_esi
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17D2E
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.24326]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A675
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F1E
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19E41
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17CEE
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+
+[6.1.7601.24402]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=1A675
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17F26
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=19E41
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17CFE
 DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
 
 [6.2.8102.0]
@@ -407,6 +617,27 @@ SLPolicyOffset.x86=19581
 SLPolicyFunc.x86=New_Win8SL
 SLPolicyInternal.x64=1
 SLPolicyOffset.x64=21FD0
+SLPolicyFunc.x64=New_Win8SL
+
+[6.2.9200.22715]
+; x86-Offsets are not safe (determined without symbols)
+SingleUserPatch.x86=1
+SingleUserOffset.x86=155B2
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=2BAE4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=13F68
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=2A396
+DefPolicyCode.x64=CDefPolicy_Query_eax_rdi
+SLPolicyInternal.x86=1
+SLPolicyOffset.x86=195B9
+SLPolicyFunc.x86=New_Win8SL
+SLPolicyInternal.x64=1
+SLPolicyOffset.x64=21F90
 SLPolicyFunc.x64=New_Win8SL
 
 [6.3.9431.0]
@@ -617,6 +848,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=5D660
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[6.3.9600.19318]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B43E8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=89EAC
+LocalOnlyCode.x64=nopjmp
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3ED25
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=35779
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3D579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=43CE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=180F8
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=5C0D0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [6.4.9841.0]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=956A8
@@ -771,6 +1028,58 @@ SLInitOffset.x86=46581
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=250F0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.10240.18036]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A7E18
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=96961
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=32715
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17264
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=2F299
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=EDC5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3F968
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=24C30
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.10240.18186]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A8048
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=96A41
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=32B15
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=17264
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=2F699
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=EDC5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3FA58
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=249D0
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.10586.0]
@@ -1397,6 +1706,48 @@ SLInitOffset.x86=45824
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=C920
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.2608]
+; no x64 version
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6248
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=45824
+SLInitFunc.x86=New_CSLQuery_Initialize
+
+
+[10.0.14393.2906]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6578
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D8A1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.14901.1000]
@@ -2157,6 +2508,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=234DC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.15063.1746]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A60D8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8CB21
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=35CA5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=15EA4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=30999
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=FAE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3F94D
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=2328C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.16179.1000]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AA568
@@ -2703,6 +3080,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=22D5C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.16299.1087]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A91F8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8FC11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=392E5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1C774
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3DD39
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=12D85
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=4626D
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22E4C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.16353.1000]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A9388
@@ -3095,6 +3498,62 @@ SLInitHook.x64=1
 SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17763.168]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFC74
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77AF1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.288]
+Patch CEnforcementCore::GetInstanceOfTSLicense
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+Patch CDefPolicy::Query
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+Hook CSLQuery::Initialize
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17763.292]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFAD4
@@ -3413,6 +3872,25 @@ bServerSku.x64        =FA068
 ulMaxDebugSessions.x64=FA06C
 bRemoteConnAllowed.x64=FA070
 
+[6.3.9600.19318-SLInit]
+bFUSEnabled.x86       =D4068
+lMaxUserSessions.x86  =D406C
+bAppServerAllowed.x86 =D4070
+bInitialized.x86      =D4074
+bMultimonAllowed.x86  =D4078
+bServerSku.x86        =D407C
+ulMaxDebugSessions.x86=D4080
+bRemoteConnAllowed.x86=D4084
+
+bFUSEnabled.x64       =FA054
+lMaxUserSessions.x64  =FA058
+bAppServerAllowed.x64 =FA05C
+bInitialized.x64      =FA060
+bMultimonAllowed.x64  =FA064
+bServerSku.x64        =FA068
+ulMaxDebugSessions.x64=FA06C
+bRemoteConnAllowed.x64=FA070
+
 [6.4.9841.0-SLInit]
 bFUSEnabled.x86       =BF9F0
 lMaxUserSessions.x86  =BF9F4
@@ -3470,6 +3948,7 @@ bServerSku.x64        =EDC04
 ulMaxDebugSessions.x64=EDC08
 bRemoteConnAllowed.x64=EDC0C
 
+
 [10.0.9926.0-SLInit]
 bFUSEnabled.x86       =C17D8
 lMaxUserSessions.x86  =C17DC
@@ -3517,6 +3996,45 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
+
+zlMaxUserSessions.x64  =F23B0
+lMaxUserSessions.x64  =F23B0
+bAppServerAllowed.x64 =F23B4
+bServerSku.x64        =F23B8
+bFUSEnabled.x64       =F3460
+bInitialized.x64      =F3464
+bMultimonAllowed.x64  =F3468
+ulMaxDebugSessions.x64=F346C
+bRemoteConnAllowed.x64=F3470
+
+[10.0.10240.18036-SLInit]
+bFUSEnabled.x86       =C3F88
+lMaxUserSessions.x86  =C3F8C
+bAppServerAllowed.x86 =C3F90
+bInitialized.x86      =C3F94
+bMultimonAllowed.x86  =C3F98
+bServerSku.x86        =C3F9C
+ulMaxDebugSessions.x86=C3FA0
+bRemoteConnAllowed.x86=C3FA4
+
+lMaxUserSessions.x64  =F23B0
+bAppServerAllowed.x64 =F23B4
+bServerSku.x64        =F23B8
+bFUSEnabled.x64       =F3460
+bInitialized.x64      =F3464
+bMultimonAllowed.x64  =F3468
+ulMaxDebugSessions.x64=F346C
+bRemoteConnAllowed.x64=F3470
+
+[10.0.10240.18186-SLInit]
+bFUSEnabled.x86       =C4F88
+lMaxUserSessions.x86  =C4F8C
+bAppServerAllowed.x86 =C4F90
+bInitialized.x86      =C4F94
+bMultimonAllowed.x86  =C4F98
+bServerSku.x86        =C4F9C
+ulMaxDebugSessions.x86=C4FA0
+bRemoteConnAllowed.x86=C4FA4
 
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
@@ -3974,6 +4492,36 @@ bRemoteConnAllowed.x86=C1FA4
 bMultimonAllowed.x86  =C1FA8
 ulMaxDebugSessions.x86=C1FAC
 bFUSEnabled.x86       =C1FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
+[10.0.14393.2608-SLInit]
+; no x64 version
+bInitialized.x86      =C1F94
+bServerSku.x86        =C1F98
+lMaxUserSessions.x86  =C1F9C
+bAppServerAllowed.x86 =C1FA0
+bRemoteConnAllowed.x86=C1FA4
+bMultimonAllowed.x86  =C1FA8
+ulMaxDebugSessions.x86=C1FAC
+bFUSEnabled.x86       =C1FB0
+
+[10.0.14393.2906-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
 
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
@@ -4537,6 +5085,28 @@ bServerSku.x64        =E9484
 lMaxUserSessions.x64  =E9488
 bAppServerAllowed.x64 =E948C
 
+
+
+[10.0.15063.1746-SLInit]
+bInitialized.x86      =C3F98
+bServerSku.x86        =C3F9C
+lMaxUserSessions.x86  =C3FA0
+bAppServerAllowed.x86 =C3FA4
+bRemoteConnAllowed.x86=C3FA8
+bMultimonAllowed.x86  =C3FAC
+ulMaxDebugSessions.x86=C3FB0
+bFUSEnabled.x86       =C3FB4
+
+bInitialized.x64      =E9468
+bRemoteConnAllowed.x64=E946C
+bMultimonAllowed.x64  =E9470
+ulMaxDebugSessions.x64=E9474
+bFUSEnabled.x64       =E9478
+bServerSku.x64        =E9484
+lMaxUserSessions.x64  =E9488
+bAppServerAllowed.x64 =E948C
+
+
 [10.0.16179.1000-SLInit]
 bInitialized.x86      =C7F6C
 bServerSku.x86        =C7F70
@@ -4936,6 +5506,27 @@ bMultimonAllowed.x64  =EE4A8
 ulMaxDebugSessions.x64=EE4AC
 bFUSEnabled.x64       =EE4B0
 
+
+
+[10.0.16299.1087-SLInit]
+bInitialized.x86      =C6F7C
+bServerSku.x86        =C6F80
+lMaxUserSessions.x86  =C6F84
+bAppServerAllowed.x86 =C6F88
+bRemoteConnAllowed.x86=C6F8C
+bMultimonAllowed.x86  =C6F90
+ulMaxDebugSessions.x86=C6F94
+bFUSEnabled.x86       =C6F98
+
+bServerSku.x64        =ED3E8
+lMaxUserSessions.x64  =ED3EC
+bAppServerAllowed.x64 =ED3F0
+bInitialized.x64      =EE4A0
+bRemoteConnAllowed.x64=EE4A4
+bMultimonAllowed.x64  =EE4A8
+ulMaxDebugSessions.x64=EE4AC
+bFUSEnabled.x64       =EE4B0
+
 [10.0.16353.1000-SLInit]
 bInitialized.x86      =C6F7C
 bServerSku.x86        =C6F80
@@ -5221,6 +5812,44 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.168-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.288-SLInit]
+bInitialized.x86 =CD798
+bServerSku.x86 =CD79C
+lMaxUserSessions.x86 =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86 =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86 =CD7B8
+
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
 
 [10.0.17763.292-SLInit]
 bInitialized.x86      =CD798

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3521,6 +3521,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=22F5C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17134.1304]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=ADAB8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=92521
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36B1C
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1511C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=33579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=10E78
+DefPolicyCode.x64=CDefPolicy_Query_edi_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=475DD
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22F5C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17723.1000]
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=75D91
@@ -5943,6 +5969,25 @@ ulMaxDebugSessions.x64=F243C
 bFUSEnabled.x64       =F2440
 
 [10.0.17134.706-SLInit]
+bInitialized.x86      =CBF38
+bServerSku.x86        =CBF3C
+lMaxUserSessions.x86  =CBF40
+bAppServerAllowed.x86 =CBF44
+bRemoteConnAllowed.x86=CBF48
+bMultimonAllowed.x86  =CBF4C
+ulMaxDebugSessions.x86=CBF50
+bFUSEnabled.x86       =CBF54
+
+bServerSku.x64        =F1378
+lMaxUserSessions.x64  =F137C
+bAppServerAllowed.x64 =F1380
+bInitialized.x64      =F2430
+bRemoteConnAllowed.x64=F2434
+bMultimonAllowed.x64  =F2438
+ulMaxDebugSessions.x64=F243C
+bFUSEnabled.x64       =F2440
+
+[10.0.17134.1304-SLInit]
 bInitialized.x86      =CBF38
 bServerSku.x86        =CBF3C
 lMaxUserSessions.x86  =CBF40

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2020-02-14
+Updated=2020-02-16
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -872,6 +872,20 @@ SLInitOffset.x86=180F8
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=5C0D0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[6.3.9600.19628]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8A07D
+LocalOnlyCode.x64=nopjmp
+SingleUserPatch.x64=1
+SingleUserOffset.x64=358E9
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=43EF5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=5C2E0
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [6.4.9841.0]
@@ -3748,7 +3762,6 @@ DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 SLInitHook.x86=1
 SLInitOffset.x86=5B30A
 SLInitFunc.x86=New_CSLQuery_Initialize
-
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77AD1
 LocalOnlyCode.x64=jmpshort
@@ -4038,6 +4051,16 @@ bServerSku.x86        =D407C
 ulMaxDebugSessions.x86=D4080
 bRemoteConnAllowed.x86=D4084
 
+bFUSEnabled.x64       =FA054
+lMaxUserSessions.x64  =FA058
+bAppServerAllowed.x64 =FA05C
+bInitialized.x64      =FA060
+bMultimonAllowed.x64  =FA064
+bServerSku.x64        =FA068
+ulMaxDebugSessions.x64=FA06C
+bRemoteConnAllowed.x64=FA070
+
+[6.3.9600.19628-SLInit]
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058
 bAppServerAllowed.x64 =FA05C
@@ -5719,8 +5742,6 @@ bMultimonAllowed.x64  =EE4A8
 ulMaxDebugSessions.x64=EE4AC
 bFUSEnabled.x64       =EE4B0
 
-
-
 [10.0.16299.1087-SLInit]
 bInitialized.x86      =C6F7C
 bServerSku.x86        =C6F80
@@ -6065,14 +6086,14 @@ ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.288-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
 bAppServerAllowed.x86 =CD7A8
 bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
+bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
+bFUSEnabled.x86       =CD7B8
 
 bInitialized.x64 =ECAB0
 bServerSku.x64 =ECAB4
@@ -6217,20 +6238,21 @@ ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
 
 [10.0.18362.657-SLInit]
-bInitialized.x86 =D577C
-bServerSku.x86 =D5780
-lMaxUserSessions.x86 =D5784
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
 bAppServerAllowed.x86 =D578C
 bRemoteConnAllowed.x86=D5790
-bMultimonAllowed.x86 =D5794
+bMultimonAllowed.x86  =D5794
 ulMaxDebugSessions.x86=D5798
-bFUSEnabled.x86 =D579C
+bFUSEnabled.x86       =D579C
 
-bInitialized.x64 =F6A8C
-bServerSku.x64 =F6A90
-lMaxUserSessions.x64 =F6A94
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
 bAppServerAllowed.x64 =F6A9C
 bRemoteConnAllowed.x64=F6AA0
-bMultimonAllowed.x64 =F6AA4
+bMultimonAllowed.x64  =F6AA4
 ulMaxDebugSessions.x64=F6AA8
-bFUSEnabled.x64 =F6AAC
+bFUSEnabled.x64       =F6AAC
+

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -2,7 +2,7 @@
 ; Do not modify without special knowledge
 
 [Main]
-Updated=2018-10-10
+Updated=2019-08-02
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -3015,6 +3015,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=22E6C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17134.706]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=ADAB8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=92521
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36B1C
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1511C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=33579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=10E78
+DefPolicyCode.x64=CDefPolicy_Query_edi_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=475DD
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22F5C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17723.1000]
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=75D91
@@ -3053,6 +3079,176 @@ SLInitOffset.x86=5B02A
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.165]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77941
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.292]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.379]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFAD4
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A11
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D665
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1322C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BE69
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17F45
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B18A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ABFC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.17763.437]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFE24
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77A41
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D7B5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1339C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BFB9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=18025
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5B2CA
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ACDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.1]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7A16
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82F35
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50515
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50249
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE05
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A75A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DCC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.53]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FB5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.267]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FB5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [SLInit]
@@ -4968,6 +5164,25 @@ bMultimonAllowed.x64  =F2438
 ulMaxDebugSessions.x64=F243C
 bFUSEnabled.x64       =F2440
 
+[10.0.17134.706-SLInit]
+bInitialized.x86      =CBF38
+bServerSku.x86        =CBF3C
+lMaxUserSessions.x86  =CBF40
+bAppServerAllowed.x86 =CBF44
+bRemoteConnAllowed.x86=CBF48
+bMultimonAllowed.x86  =CBF4C
+ulMaxDebugSessions.x86=CBF50
+bFUSEnabled.x86       =CBF54
+
+bServerSku.x64        =F1378
+lMaxUserSessions.x64  =F137C
+bAppServerAllowed.x64 =F1380
+bInitialized.x64      =F2430
+bRemoteConnAllowed.x64=F2434
+bMultimonAllowed.x64  =F2438
+ulMaxDebugSessions.x64=F243C
+bFUSEnabled.x64       =F2440
+
 [10.0.17723.1000-SLInit]
 bInitialized.x64      =E9AB0
 bServerSku.x64        =E9AB4
@@ -4996,3 +5211,127 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.165-SLInit]
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.292-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+bInitialized.x64      =ECAB0
+
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.379-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.17763.437-SLInit]
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
+bAppServerAllowed.x86 =CD7A8
+bRemoteConnAllowed.x86=CD7AC
+bMultimonAllowed.x86  =CD7B0
+ulMaxDebugSessions.x86=CD7B4
+bFUSEnabled.x86       =CD7B8
+
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64  =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64       =ECAD0
+
+[10.0.18362.1-SLInit]
+bInitialized.x86      =D477C
+bServerSku.x86        =D4780
+lMaxUserSessions.x86  =D4784
+bAppServerAllowed.x86 =D478C
+bRemoteConnAllowed.x86=D4790
+bMultimonAllowed.x86  =D4794
+ulMaxDebugSessions.x86=D4798
+bFUSEnabled.x86       =D479C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC
+
+[10.0.18362.53-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC
+
+[10.0.18362.267-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC


### PR DESCRIPTION
# RDP Wrapper & Autoupdate

### Automatic RDP Wrapper installer and updater // asmtron (07-06-2020)

#### Info:
   The Autoupdater (autoupdate.bat) first use and check the official rdpwrap.ini.
   If a new termsrv.dll is not supported in the offical rdpwrap.ini,
   autoupdater first tries the asmtron rdpwrap.ini. The autoupdater will also use rdpwrap.ini files
   of other contributors. Extra rdpwrap.ini sources can also be defined...
   
#### autoupdate.bat Options:
- -log        = redirect display output to the file autoupdate.log
- -taskadd    = add autorun of autoupdate.bat on startup in schedule task
- -taskremove = remove autorun of autoupdate.bat on startup in schedule task

#### [Download and Install](https://github.com/asmtron/rdpwrap/blob/master/binary-download.md)

#
## NEWS
2020-12-06 -- add support for 10.0.19041.84 (x64)