### PR TITLE
Support for TermService 10.0.18362.836

### DIFF
--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -4996,3 +4996,49 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
+
+
+[10.0.18362.836]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=82FC5
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50515
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=DBFC
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50249
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE15
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A75A
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22DDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18362.836-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC


### PR DESCRIPTION
Works on Windows 10 Pro version 1909 Build 18363.836

![image](https://user-images.githubusercontent.com/784590/84203693-dcc5c480-aa77-11ea-922c-79ea1621e731.png)
