### PR TITLE
Remove ActiveX Warning Popup for rdpcheck

### DIFF
--- a/src-rdpcheck/MainUnit.dfm
+++ b/src-rdpcheck/MainUnit.dfm
@@ -17,11 +17,12 @@ object Frm: TFrm
   OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
-  object RDP: TMsRdpClient2
+  object RDP: TMsRdpClient2NotSafeForScripting
     Left = 0
     Top = 0
     Width = 640
     Height = 480
+    Align = alClient
     TabOrder = 0
     OnDisconnected = RDPDisconnected
     ControlData = {0003000008000200000000000B0000000B000000}

--- a/src-rdpcheck/MainUnit.pas
+++ b/src-rdpcheck/MainUnit.pas
@@ -24,7 +24,7 @@ uses
 
 type
   TFrm = class(TForm)
-    RDP: TMsRdpClient2;
+    RDP: TMsRdpClient2NotSafeForScripting;
     procedure RDPDisconnected(ASender: TObject; discReason: Integer);
     procedure FormCreate(Sender: TObject);
   private


### PR DESCRIPTION
No more ActiveX Warning popup for the RDPCheck utility
![image](https://user-images.githubusercontent.com/784590/85847746-f94f4580-b775-11ea-8a83-9a0b11ee87a3.png)
